### PR TITLE
display queries and fix bug outputting the sidebar menu item twice

### DIFF
--- a/php/Output_Save_Post_Queries.php
+++ b/php/Output_Save_Post_Queries.php
@@ -86,21 +86,8 @@ class Output_Save_Post_Queries extends \QM_Output_Html_DB_Queries {
 						</td>
 					</tr>
 				<?php endif; ?>
-				<?php if ( ! empty( $data['dbs'] ) && is_array( $data['dbs'] ) ) : ?>
-					<tr class="all-save-post-queries-row">
-						<td class="qm-ltr">
-							<div class="all-save-post-queries-wrapper" style="padding: 30px 0;">
-								<button><?php esc_html_e( 'Show/hide all save post queries', 'query-monitor' ); ?></button>
-								<div class="all-save-post-queries hidden">
-									<?php
-										foreach ( $data['dbs'] as $name => $db ) {
-											$this->output_queries( $name, $db, $data );
-										}
-									?>
-								</div>
-							</div>
-						</td>
-					</tr>
+				<?php if ( ! empty( $data ) ) : ?>
+					<?php $this->output_queries( $data ); ?>
 				<?php endif; ?>
 				</tbody>
 			</table>
@@ -128,11 +115,11 @@ class Output_Save_Post_Queries extends \QM_Output_Html_DB_Queries {
 			return $menu;
 		}
 
-		$menu[] = $this->menu( array(
+		$menu['qm-save_post_queries'] = $this->menu( [
 			'id'    => 'qm-' . QMSPQ_COLLECTOR_NAME,
 			'href'  => '#qm-' . QMSPQ_COLLECTOR_NAME,
 			'title' => sprintf( __( 'Save post queries (%s)', 'query-monitor' ), absint( $this->save_post_queries_data['save_post_queries_count'] ) ),
-		) );
+		] );
 
 		return $menu;
 	}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4

## 📑 Description
Displays collected queries during Post Save. Note that this doesn't not yet work with Gutenberg editors, since the post save in Gutenberg happens via REST. This plugin only works with POST requests made by/on the server.
<!-- Add a brief description of the pr -->


## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
Thanks [@columbian-chris](https://github.com/columbian-chris) for the issue!
